### PR TITLE
Fixed injected LIDs not using new LID subcatchments

### DIFF
--- a/ostrich_swmm/inject.py
+++ b/ostrich_swmm/inject.py
@@ -277,6 +277,9 @@ def inject_parameters_into_input(input_parameters, input_template):
                     lid_num_units,
                 ),
             })
+
+            # Set the LID subcatchment to the child subcatchment.
+            lid['location']['subcatchment'] = lid_sc_name
         else:
             logging.warning(
                 (

--- a/ostrich_swmm/version.py
+++ b/ostrich_swmm/version.py
@@ -1,3 +1,3 @@
 """Specifies the version of this package."""
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'


### PR DESCRIPTION
This pull request fixes a bug where the LIDs injected by OSTRICH-SWMM did not use the subcatchments created specifically for them during the injection process.