### PR TITLE
Added subcommand to run SWMM with pre- and post-processing steps

### DIFF
--- a/ostrich_swmm/__main__.py
+++ b/ostrich_swmm/__main__.py
@@ -66,43 +66,35 @@ def load_config_with_args(args):
     return config
 
 
-def extract_cmd(args):
+def extract_cmd(config):
     """Extract data from a SWMM binary output file.
 
     Args:
-        args (dict): Command-line arguments to use.
+        config (dict): The configuration to use.
 
     Returns:
         int: An exit code for the script.
 
     Raises:
-        ConfigException: The configuration could not be validated.
-        IOError: The config file was not found or was not readable.
-        UsageException: The configuration file was not found.
-        ValueError: The config file was not valid JSON.
+        ConfigException: The configuration was invalid.
     """
-    config = load_config_with_args(args)
     extract.perform_extraction_steps(config)
 
     return 0
 
 
-def inject_cmd(args):
+def inject_cmd(config):
     """Inject OSTRICH parameters into SWMM input before a run.
 
     Args:
-        args (dict): Command-line arguments to use.
+        config (dict): The configuration to use.
 
     Returns:
         int: An exit code for the script.
 
     Raises:
-        ConfigException: The configuration could not be validated.
-        IOError: The config file was not found or was not readable.
-        UsageException: The configuration file was not found.
-        ValueError: The config file was not valid JSON.
+        ConfigException: The configuration was invalid.
     """
-    config = load_config_with_args(args)
     inject.perform_injection(config)
 
     return 0
@@ -217,13 +209,14 @@ def main(argv=None):
 
         # Parse arguments.
         args = vars(parser.parse_args(argv[1:]))
+        config = load_config_with_args(args)
 
         # Call selected subcommand.
         subcommands = {
             'extract': extract_cmd,
             'inject': inject_cmd,
         }
-        return subcommands[args['subcommand']](args)
+        return subcommands[args['subcommand']](config)
     except (UsageException, cfg.ConfigException) as e:
         print(e.msg, file=sys.stderr)
         print('For help, use --help or [sub-command] --help.', file=sys.stderr)

--- a/ostrich_swmm/__main__.py
+++ b/ostrich_swmm/__main__.py
@@ -9,6 +9,7 @@ import sys
 from . import config as cfg
 from . import extract
 from . import inject
+from . import run
 from .version import __version__
 
 
@@ -96,6 +97,23 @@ def inject_cmd(config):
         ConfigException: The configuration was invalid.
     """
     inject.perform_injection(config)
+
+    return 0
+
+
+def run_cmd(config):
+    """Run SWMM with pre- and post-processing steps.
+
+    Args:
+        config (dict): The configuration to use.
+
+    Returns:
+        int: An exit code for the script.
+
+    Raises:
+        ConfigException: The configuration was invalid.
+    """
+    run.perform_run(config)
 
     return 0
 
@@ -207,6 +225,15 @@ def main(argv=None):
             ],
         )
 
+        # Set up parsing for the run sub-command.
+        subparsers.add_parser(
+            'run',
+            help='Run SWMM with pre- and post-processing steps.',
+            parents=[
+                config_parser,
+            ],
+        )
+
         # Parse arguments.
         args = vars(parser.parse_args(argv[1:]))
         config = load_config_with_args(args)
@@ -215,6 +242,7 @@ def main(argv=None):
         subcommands = {
             'extract': extract_cmd,
             'inject': inject_cmd,
+            'run': run_cmd,
         }
         return subcommands[args['subcommand']](config)
     except (UsageException, cfg.ConfigException) as e:

--- a/ostrich_swmm/config.py
+++ b/ostrich_swmm/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 
+import distutils.spawn
 import json
 import os
 
@@ -95,6 +96,8 @@ def validate_config(config):
     if 'summary_dir' in config:
         if config['summary_dir'] == '':
             config['summary_dir'] = os.curdir
+    if 'swmm_path' not in config:
+        config['swmm_path'] = 'swmm5'
 
 
 def validate_against_json_schema(o, schema_path):
@@ -117,6 +120,27 @@ def validate_against_json_schema(o, schema_path):
         jsonschema.validate(o, schema)
     except jsonschema.ValidationError as e:
         raise ConfigException(e.message)
+
+
+def validate_executable_path(config, section):
+    """Validate that a path to an executable is valid.
+
+    Args:
+        config (dict): A configuration with an executable path to check.
+        section (string): The key to the executable path to check.
+
+    Raises:
+        ConfigException: The path was not valid.
+    """
+    executable_path = config[section]
+    if not distutils.spawn.find_executable(executable_path):
+        raise ConfigException(
+            (
+                'Executable "{0}" could not be found in PATH '
+                'or on file system.'
+            ).format(executable_path),
+            section,
+        )
 
 
 def validate_file_exists(config, section):

--- a/ostrich_swmm/data/schemas/config.schema.json
+++ b/ostrich_swmm/data/schemas/config.schema.json
@@ -19,6 +19,14 @@
             "type": "string",
             "minLength": 1
         },
+        "report_output_path": {
+            "type": "string",
+            "minLength": 1
+        },
+        "swmm_path": {
+            "type": "string",
+            "minLength": 1
+        },
         "summary_dir": {
             "type": "string"
         },

--- a/ostrich_swmm/extract.py
+++ b/ostrich_swmm/extract.py
@@ -94,22 +94,19 @@ def perform_node_extraction(
     csv_writer.writerows(zip(*csv_columns))
 
 
-def perform_extraction_steps(config):
+def perform_extraction_steps(config, validate=True):
     """Perform the extraction steps specified in a configuration.
 
     Args:
         config: The config to get extraction steps from.
+        validate (boolean): Validate the configuration before attempting
+            to use it. Defaults to True.
 
     Raises:
         ConfigException: The configuration is invalid.
     """
-    cfg.validate_required_sections(config, [
-        'binary_output_path',
-        'summary_dir',
-        'extract',
-    ], 'extract')
-    cfg.validate_file_exists(config, 'binary_output_path')
-    cfg.validate_dir_exists(config, 'summary_dir')
+    if validate:
+        validate_config(config)
 
     binary_output = swmmtoolbox.SwmmExtract(
         config['binary_output_path']
@@ -143,3 +140,25 @@ def perform_extraction_steps(config):
             perform_node_extraction(**node_extraction_args)
 
             node_output_file.close()
+
+
+def validate_config(config, perform_file_checks=True):
+    """Validate a configuration for use with this functionality.
+
+    Args:
+        config (dict): The configuration to validate.
+        perform_file_checks (boolean): Check if required files exist.
+            Defaults to true.
+
+    Raises:
+        ConfigException: The configuration is invalid.
+    """
+    cfg.validate_required_sections(config, [
+        'binary_output_path',
+        'summary_dir',
+        'extract',
+    ], 'extract')
+
+    if perform_file_checks:
+        cfg.validate_file_exists(config, 'binary_output_path')
+        cfg.validate_dir_exists(config, 'summary_dir')

--- a/ostrich_swmm/inject.py
+++ b/ostrich_swmm/inject.py
@@ -322,24 +322,20 @@ def inject_parameters_into_input(input_parameters, input_template):
         })
 
 
-def perform_injection(config):
+def perform_injection(config, validate=True):
     """Perform the injection as specified in a configuration.
 
     Args:
         config: The config to get injection configuration from.
+        validate (boolean): Validate the configuration before attempting
+            to use it. Defaults to True.
 
     Raises:
         ConfigException: The configuration is invalid.
         IOError: An error occurred during reading or writing.
     """
-    cfg.validate_required_sections(config, [
-        'input_path',
-        'input_template_path',
-        'input_parameters_path',
-    ], 'inject')
-    cfg.validate_file_exists(config, 'input_template_path')
-    cfg.validate_file_exists(config, 'input_parameters_path')
-    cfg.validate_dir_exists(config, 'input_path', path_is_file=True)
+    if validate:
+        validate_config(config)
 
     with open(config['input_template_path']) as input_template_file:
         input_template = sir.read(input_template_file)
@@ -351,3 +347,22 @@ def perform_injection(config):
 
     with open(config['input_path'], 'w') as input_file:
         siw.write(input_template, input_file)
+
+
+def validate_config(config):
+    """Validate a configuration for use with this functionality.
+
+    Args:
+        config (dict): The configuration to validate.
+
+    Raises:
+        ConfigException: The configuration is invalid.
+    """
+    cfg.validate_required_sections(config, [
+        'input_path',
+        'input_template_path',
+        'input_parameters_path',
+    ], 'inject')
+    cfg.validate_file_exists(config, 'input_template_path')
+    cfg.validate_file_exists(config, 'input_parameters_path')
+    cfg.validate_dir_exists(config, 'input_path', path_is_file=True)

--- a/ostrich_swmm/run.py
+++ b/ostrich_swmm/run.py
@@ -1,0 +1,64 @@
+"""Functionality for running SWMM with pre- and post-processing steps."""
+
+import subprocess
+
+from . import config as cfg
+from . import extract
+from . import inject
+
+
+def perform_run(config, validate=True):
+    """Perform a run as specified by a configuration.
+
+    Args:
+        config: The config to get run information from.
+        validate (boolean): Validate the configuration before attempting
+            to use it. Defaults to True.
+
+    Raises:
+        ConfigException: The configuration is invalid.
+    """
+    if validate:
+        validate_config(config)
+
+    inject.perform_injection(config, validate=False)
+
+    input_path = config['input_path']
+    binary_output_path = config['binary_output_path']
+    report_output_path = config.get('report_output_path')
+    if report_output_path is None:
+        if binary_output_path.endswith('.out'):
+            report_base_path = binary_output_path[:-4]
+        else:
+            report_base_path = binary_output_path
+        report_output_path = '{0}.rpt'.format(report_base_path)
+
+    subprocess.call([
+        config['swmm_path'],
+        input_path,
+        report_output_path,
+        binary_output_path,
+    ])
+
+    extract.perform_extraction_steps(config, validate=False)
+
+
+def validate_config(config):
+    """Validate a configuration for use with this functionality.
+
+    Args:
+        config (dict): The configuration to validate.
+
+    Raises:
+        ConfigException: The configuration is invalid.
+    """
+    cfg.validate_required_sections(config, [
+        'binary_output_path',
+        'input_path',
+        'swmm_path',
+    ], 'run')
+    cfg.validate_executable_path(config, 'swmm_path')
+
+    # Validate with modules used by this module.
+    inject.validate_config(config)
+    extract.validate_config(config, perform_file_checks=False)

--- a/templates/ostrich-swmm-config.json
+++ b/templates/ostrich-swmm-config.json
@@ -3,7 +3,9 @@
     "input_template_path": "swmm.template.inp",
     "input_parameters_path": "swmm_input_parameters.json",
     "input_path": "swmm.inp",
+    "report_output_path": "swmm.rpt",
     "summary_dir": ".",
+    "swmm_path": "swmm5",
     "extract": {
         "steps": [
             {


### PR DESCRIPTION
This pull request adds the ability to run SWMM with input parameter injection before a run and output metric extraction after a run. This subcommand is designed to make invocation from OSTRICH simple.

By default, the command will use the `swmm5` executable found in the system's `PATH`, but the config file can specify another path to use instead.